### PR TITLE
Templates functionality, reorganize into sub-resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+secrets/
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# postmark
-Go client library for the Postmark API
+# Postmark API
+
+[![Godoc](https://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square)](https://godoc.org/github.com/rastech/postmark)
+
+A Go client library for the [Postmark API](http://developer.postmarkapp.com). This is currently a partial implementation based on internal needs for Meta, existing functionality can be added as necessary.
+
+Though the currently implemented API for this library should be fairly stable, it may change to accomodate further resources in the future.
+
+## Progress
+
+- [x] Email
+- [ ] Bounce
+- [x] Templates
+- [ ] Server
+- [ ] Servers
+- [ ] Messages
+- [ ] Sender Signatures
+- [ ] Stats
+- [ ] Triggers

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Postmark API
 
 [![Godoc](https://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square)](https://godoc.org/github.com/rastech/postmark)
+[![License](https://img.shields.io/badge/license-Apache%202.0-red.svg?style=flat-squared)](https://github.com/rastech/postmark/blob/master/LICENSE)
+
 
 A Go client library for the [Postmark API](http://developer.postmarkapp.com). This is currently a partial implementation based on internal needs for Meta, existing functionality can be added as necessary.
 

--- a/emails.go
+++ b/emails.go
@@ -1,8 +1,10 @@
 package postmark
 
 import (
-	"golang.org/x/net/context"
+	"path"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // Emails defines the functionality of the emails resource
@@ -71,7 +73,7 @@ func (e *emails) Email(ctx context.Context, email *Email) (*EmailResponse, error
 	er := new(EmailResponse)
 	_, err := e.pm.Exec(ctx, &Request{
 		Method:  "POST",
-		Path:    "/email",
+		Path:    "email",
 		Payload: email,
 		Target:  er,
 	})
@@ -94,7 +96,7 @@ func (e *emails) EmailWithTemplate(ctx context.Context, email *EmailWithTemplate
 	er := new(EmailResponse)
 	_, err := e.pm.Exec(ctx, &Request{
 		Method:  "POST",
-		Path:    "/email/withTemplate/",
+		Path:    path.Join("email", "withTemplate"),
 		Payload: email,
 		Target:  er,
 	})

--- a/emails.go
+++ b/emails.go
@@ -1,0 +1,105 @@
+package postmark
+
+import (
+	"golang.org/x/net/context"
+	"time"
+)
+
+// Emails defines the functionality of the emails resource
+type Emails interface {
+	// Email sends a single email with custom content.
+	// http://developer.postmarkape.com/developer-api-email.html#send-email
+	Email(ctx context.Context, email *Email) (*EmailResponse, error)
+
+	// EmailWithTemplate sends an email with templated content.
+	// http://developer.postmarkape.com/developer-api-templates.html#email-with-template
+	EmailWithTemplate(ctx context.Context, email *EmailWithTemplate) (*EmailResponse, error)
+}
+
+type emails struct {
+	pm *postmark
+}
+
+var _ Emails = (*emails)(nil)
+
+// BaseEmail defines the fields common to all Postmark emails
+type BaseEmail struct {
+	From        string       `json:",omitempty"`
+	To          string       `json:",omitempty"`
+	Cc          string       `json:",omitempty"`
+	Bcc         string       `json:",omitempty"`
+	Tag         string       `json:",omitempty"`
+	ReplyTo     string       `json:",omitempty"`
+	Headers     []Header     `json:",omitempty"`
+	TrackOpens  bool         `json:",omitempty"`
+	Attachments []Attachment `json:",omitempty"`
+}
+
+// Header defines an email header within the Postmark API
+type Header struct {
+	Name  string
+	Value string
+}
+
+// Attachment defines an email attachment within the Postmark API
+type Attachment struct {
+	Name        string
+	Content     string
+	ContentType string
+}
+
+// EmailResponse is the response from the postmark API after an email is sent.
+// This can also be an error type for unsuccesful calls.
+type EmailResponse struct {
+	To          string
+	SubmittedAt time.Time
+	MessageID   string
+	ErrorCode   int
+	Message     string
+}
+
+// Email defines an email object within the Postmark API
+type Email struct {
+	BaseEmail
+
+	Subject  string
+	HTMLBody string `json:"HtmlBody"`
+	TextBody string
+}
+
+func (e *emails) Email(ctx context.Context, email *Email) (*EmailResponse, error) {
+	er := new(EmailResponse)
+	_, err := e.pm.Exec(ctx, &Request{
+		Method:  "POST",
+		Path:    "/email",
+		Payload: email,
+		Target:  er,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return er, nil
+}
+
+// EmailWithTemplate defines a templated email to the postmark API
+type EmailWithTemplate struct {
+	BaseEmail
+
+	TemplateID    string `json:"TemplateId"`
+	TemplateModel map[string]interface{}
+	InlineCSS     bool `json:"InlineCss,omitempty"`
+}
+
+func (e *emails) EmailWithTemplate(ctx context.Context, email *EmailWithTemplate) (*EmailResponse, error) {
+	er := new(EmailResponse)
+	_, err := e.pm.Exec(ctx, &Request{
+		Method:  "POST",
+		Path:    "/email/withTemplate/",
+		Payload: email,
+		Target:  er,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return er, nil
+}

--- a/postmark.go
+++ b/postmark.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	pmRootEndpoint = "https://api.postmarkapp.com"
+	rootEndpoint = "https://api.postmarkapp.com"
 
-	pmServerTokenHeader  = "X-Postmark-Server-Token"
-	pmAccountTokenHeader = "X-Postmark-Account-Token"
+	serverTokenHeader  = "X-Postmark-Server-Token"
+	accountTokenHeader = "X-Postmark-Account-Token"
 )
 
 // Postmark defines methods to interace with the Postmark API
@@ -71,7 +71,7 @@ func (p *postmark) Exec(ctx context.Context, req *Request) (*http.Response, erro
 		payload = bytes.NewReader(data)
 	}
 
-	r, err := http.NewRequest(req.Method, pmRootEndpoint+req.Path, payload)
+	r, err := http.NewRequest(req.Method, rootEndpoint+req.Path, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -80,9 +80,9 @@ func (p *postmark) Exec(ctx context.Context, req *Request) (*http.Response, erro
 	r.Header.Set("Content-Type", "application/json")
 
 	if req.AccountAuth {
-		r.Header.Set("X-Postmark-Account-Token", p.accountToken)
+		r.Header.Set(accountTokenHeader, p.accountToken)
 	} else {
-		r.Header.Set("X-Postmark-Server-Token", p.serverToken)
+		r.Header.Set(serverTokenHeader, p.serverToken)
 	}
 
 	resp, err := p.httpclient().Do(r)

--- a/postmark.go
+++ b/postmark.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/net/context"
 	"io"
 	"net/http"
+	"path"
 )
 
 const (
@@ -71,7 +72,7 @@ func (p *postmark) Exec(ctx context.Context, req *Request) (*http.Response, erro
 		payload = bytes.NewReader(data)
 	}
 
-	r, err := http.NewRequest(req.Method, rootEndpoint+req.Path, payload)
+	r, err := http.NewRequest(req.Method, path.Join(rootEndpoint, req.Path), payload)
 	if err != nil {
 		return nil, err
 	}

--- a/postmark.go
+++ b/postmark.go
@@ -22,11 +22,11 @@ type Postmark interface {
 
 	// Email sends a single email with custom content.
 	// http://developer.postmarkapp.com/developer-api-email.html#send-email
-	Email(ctx context.Context, email *Email) error
+	Email(ctx context.Context, email *Email) (*EmailResponse, error)
 
 	// EmailWithTemplate sends an email with templated content.
 	// http://developer.postmarkapp.com/developer-api-templates.html#email-with-template
-	EmailWithTemplate(ctx context.Context, email *EmailWithTemplate) error
+	EmailWithTemplate(ctx context.Context, email *EmailWithTemplate) (*EmailResponse, error)
 }
 
 type postmark struct {
@@ -180,7 +180,7 @@ type Email struct {
 	TextBody string
 }
 
-func (p *postmark) Email(ctx context.Context, email *Email) error {
+func (p *postmark) Email(ctx context.Context, email *Email) (*EmailResponse, error) {
 	er := new(EmailResponse)
 	_, err := p.Exec(ctx, &Request{
 		Method:  "POST",
@@ -189,9 +189,9 @@ func (p *postmark) Email(ctx context.Context, email *Email) error {
 		Target:  er,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return er, nil
 }
 
 // EmailWithTemplate defines a templated email to the postmark API
@@ -203,7 +203,7 @@ type EmailWithTemplate struct {
 	InlineCSS     bool `json:"InlineCss,omitempty"`
 }
 
-func (p *postmark) EmailWithTemplate(ctx context.Context, email *EmailWithTemplate) error {
+func (p *postmark) EmailWithTemplate(ctx context.Context, email *EmailWithTemplate) (*EmailResponse, error) {
 	er := new(EmailResponse)
 	_, err := p.Exec(ctx, &Request{
 		Method:  "POST",
@@ -212,7 +212,7 @@ func (p *postmark) EmailWithTemplate(ctx context.Context, email *EmailWithTempla
 		Target:  er,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return er, nil
 }

--- a/postmark.go
+++ b/postmark.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/net/context"
 	"io"
 	"net/http"
 	"path"
+
+	"golang.org/x/net/context"
 )
 
 const (

--- a/templates.go
+++ b/templates.go
@@ -1,10 +1,11 @@
 package postmark
 
 import (
-	"golang.org/x/net/context"
 	"net/url"
 	"path"
 	"strconv"
+
+	"golang.org/x/net/context"
 )
 
 // Templates defines the functionality of the template resource
@@ -60,7 +61,7 @@ func (t *templates) Get(ctx context.Context, id string) (*Template, error) {
 	tmpl := new(Template)
 	_, err := t.pm.Exec(ctx, &Request{
 		Method: "GET",
-		Path:   path.Join("/templates/", id),
+		Path:   path.Join("templates", id),
 		Target: tmpl,
 	})
 	if err != nil {
@@ -83,7 +84,7 @@ func (t *templates) Create(ctx context.Context, tmpl *Template) (*TemplateResp, 
 	tmplResp := new(TemplateResp)
 	_, err := t.pm.Exec(ctx, &Request{
 		Method:  "POST",
-		Path:    "/templates/",
+		Path:    "templates",
 		Payload: tmpl,
 		Target:  tmplResp,
 	})
@@ -97,7 +98,7 @@ func (t *templates) Edit(ctx context.Context, id string, tmpl *Template) (*Templ
 	tmplResp := new(TemplateResp)
 	_, err := t.pm.Exec(ctx, &Request{
 		Method:  "PUT",
-		Path:    path.Join("/templates", id),
+		Path:    path.Join("templates", id),
 		Payload: tmpl,
 		Target:  tmplResp,
 	})
@@ -115,7 +116,7 @@ type TemplateList struct {
 
 func (t *templates) List(ctx context.Context, count, offset int) (*TemplateList, error) {
 	urlBuilder := url.URL{
-		Path: "/templates",
+		Path: "templates",
 		RawQuery: url.Values{
 			"count":  {strconv.Itoa(count)},
 			"offset": {strconv.Itoa(offset)},
@@ -138,7 +139,7 @@ func (t *templates) Delete(ctx context.Context, id string) (*TemplateResp, error
 	tmplResp := new(TemplateResp)
 	_, err := t.pm.Exec(ctx, &Request{
 		Method: "DELETE",
-		Path:   path.Join("/templates", id),
+		Path:   path.Join("templates", id),
 		Target: tmplResp,
 	})
 	if err != nil {
@@ -176,7 +177,7 @@ func (t *templates) Validate(ctx context.Context, tmpl *TemplateValidation) (*Te
 	tmplResp := new(TemplateValidationResp)
 	_, err := t.pm.Exec(ctx, &Request{
 		Method:  "POST",
-		Path:    "/templates/validate",
+		Path:    path.Join("templates", "validate"),
 		Payload: tmpl,
 		Target:  tmplResp,
 	})

--- a/templates.go
+++ b/templates.go
@@ -1,0 +1,181 @@
+package postmark
+
+import (
+	"golang.org/x/net/context"
+	"net/url"
+	"strconv"
+)
+
+// Templates defines the functionality of the template resource
+type Templates interface {
+	// Get retrieves an individual template
+	// http://developer.postmarkapp.com/developer-api-templates.html#get-template
+	Get(ctx context.Context, id string) (*Template, error)
+
+	// Create creates a new template within Postmark
+	// http://developer.postmarkapp.com/developer-api-templates.html#create-template
+	Create(ctx context.Context, tmpl *Template) (*TemplateResp, error)
+
+	// Edit modifies an existing template
+	// http://developer.postmarkapp.com/developer-api-templates.html#edit-template
+	Edit(ctx context.Context, id string, tmpl *Template) (*TemplateResp, error)
+
+	// List returns a list of all existing templates
+	// http://developer.postmarkapp.com/developer-api-templates.html#template-list
+	List(ctx context.Context, count, offset int) (*TemplateList, error)
+
+	// Delete permanently deletes a template from Postmark
+	// http://developer.postmarkapp.com/developer-api-templates.html#delete-template
+	Delete(ctx context.Context, id string) (*TemplateResp, error)
+
+	// Validate allows a template's validity to be checked without sending the template
+	// http://developer.postmarkapp.com/developer-api-templates.html#validate-template
+	Validate(ctx context.Context, tmpl *TemplateValidation) (*TemplateValidationResp, error)
+}
+
+type templates struct {
+	pm *postmark
+}
+
+var _ Templates = (*templates)(nil)
+
+// Template defines the template entities within postmark
+type Template struct {
+	TemplateID         int64 `json:"TemplateId"`
+	Name               string
+	Subject            string
+	HTMLBody           string `json:"HtmlBody"`
+	TextBody           string
+	AssociatedServerID int64 `json:"AssociatedServerId"`
+	Active             bool
+}
+
+func (t *templates) Get(ctx context.Context, id string) (*Template, error) {
+	tmpl := new(Template)
+	_, err := t.pm.Exec(ctx, &Request{
+		Method: "GET",
+		Path:   "/templates/" + id,
+		Target: tmpl,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tmpl, nil
+}
+
+// TemplateResp defines the response after template manipulation
+type TemplateResp struct {
+	TemplateID int64 `json:"TemplateId"`
+	Name       string
+	Active     bool
+
+	ErrorCode int
+	Message   string
+}
+
+func (t *templates) Create(ctx context.Context, tmpl *Template) (*TemplateResp, error) {
+	tmplResp := new(TemplateResp)
+	_, err := t.pm.Exec(ctx, &Request{
+		Method:  "POST",
+		Path:    "/templates/",
+		Payload: tmpl,
+		Target:  tmplResp,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tmplResp, nil
+}
+
+func (t *templates) Edit(ctx context.Context, id string, tmpl *Template) (*TemplateResp, error) {
+	tmplResp := new(TemplateResp)
+	_, err := t.pm.Exec(ctx, &Request{
+		Method:  "PUT",
+		Path:    "/templates/" + id,
+		Payload: tmpl,
+		Target:  tmplResp,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tmplResp, nil
+}
+
+// TemplateList defines a list of template entities
+type TemplateList struct {
+	TemplateCount int64
+	Templates     []*Template
+}
+
+func (t *templates) List(ctx context.Context, count, offset int) (*TemplateList, error) {
+	urlBuilder := url.URL{
+		Path: "/templates",
+		RawQuery: url.Values{
+			"count":  {strconv.Itoa(count)},
+			"offset": {strconv.Itoa(offset)},
+		}.Encode(),
+	}
+
+	tmplList := new(TemplateList)
+	_, err := t.pm.Exec(ctx, &Request{
+		Method: "GET",
+		Path:   urlBuilder.String(),
+		Target: tmplList,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tmplList, nil
+}
+
+func (t *templates) Delete(ctx context.Context, id string) (*TemplateResp, error) {
+	tmplResp := new(TemplateResp)
+	_, err := t.pm.Exec(ctx, &Request{
+		Method: "DELETE",
+		Path:   "/templates/" + id,
+		Target: tmplResp,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tmplResp, nil
+}
+
+// TemplateValidation defines the structure of a template sent for validation with the API
+type TemplateValidation struct {
+	Subject                    string
+	HTMLBody                   string `json:"HtmlBody"`
+	TextBody                   string
+	TestRenderModel            map[string]interface{}
+	InlineCSSForHTMLTestRender bool `json:"InlineCssForHtmlTestRender"`
+}
+
+// TemplateValidationResp defines the result of a template validation call
+type TemplateValidationResp struct {
+	AllContentIsValid      bool
+	ContentIsValid         bool
+	ValidationErrors       []TemplateValidationErr
+	RenderedContent        string
+	SuggestedTemplateModel map[string]interface{}
+}
+
+// TemplateValidationErr defines an error that occured while validating a template
+type TemplateValidationErr struct {
+	Message           string
+	Line              int
+	CharacterPosition int
+}
+
+func (t *templates) Validate(ctx context.Context, tmpl *TemplateValidation) (*TemplateValidationResp, error) {
+	tmplResp := new(TemplateValidationResp)
+	_, err := t.pm.Exec(ctx, &Request{
+		Method:  "POST",
+		Path:    "/templates/validate",
+		Payload: tmpl,
+		Target:  tmplResp,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tmplResp, nil
+}

--- a/templates.go
+++ b/templates.go
@@ -3,6 +3,7 @@ package postmark
 import (
 	"golang.org/x/net/context"
 	"net/url"
+	"path"
 	"strconv"
 )
 
@@ -54,7 +55,7 @@ func (t *templates) Get(ctx context.Context, id string) (*Template, error) {
 	tmpl := new(Template)
 	_, err := t.pm.Exec(ctx, &Request{
 		Method: "GET",
-		Path:   "/templates/" + id,
+		Path:   path.Join("/templates/", id),
 		Target: tmpl,
 	})
 	if err != nil {
@@ -91,7 +92,7 @@ func (t *templates) Edit(ctx context.Context, id string, tmpl *Template) (*Templ
 	tmplResp := new(TemplateResp)
 	_, err := t.pm.Exec(ctx, &Request{
 		Method:  "PUT",
-		Path:    "/templates/" + id,
+		Path:    path.Join("/templates", id),
 		Payload: tmpl,
 		Target:  tmplResp,
 	})
@@ -132,7 +133,7 @@ func (t *templates) Delete(ctx context.Context, id string) (*TemplateResp, error
 	tmplResp := new(TemplateResp)
 	_, err := t.pm.Exec(ctx, &Request{
 		Method: "DELETE",
-		Path:   "/templates/" + id,
+		Path:   path.Join("/templates", id),
 		Target: tmplResp,
 	})
 	if err != nil {

--- a/templates.go
+++ b/templates.go
@@ -32,6 +32,11 @@ type Templates interface {
 	// Validate allows a template's validity to be checked without sending the template
 	// http://developer.postmarkapp.com/developer-api-templates.html#validate-template
 	Validate(ctx context.Context, tmpl *TemplateValidation) (*TemplateValidationResp, error)
+
+	// Email sends an email with the given template. This is a wrapper around the `EmailWithTemplate`
+	// method that lives on the `Emails` resource, but lives here in order to match the Postmark docs.
+	// http://developer.postmarkapp.com/developer-api-templates.html#email-with-template
+	Email(ctx context.Context, email *EmailWithTemplate) (*EmailResponse, error)
 }
 
 type templates struct {
@@ -179,4 +184,8 @@ func (t *templates) Validate(ctx context.Context, tmpl *TemplateValidation) (*Te
 		return nil, err
 	}
 	return tmplResp, nil
+}
+
+func (t *templates) Email(ctx context.Context, email *EmailWithTemplate) (*EmailResponse, error) {
+	return t.pm.Emails().EmailWithTemplate(ctx, email)
 }


### PR DESCRIPTION
This PR adds functionality for Postmark's [templates API](http://developer.postmarkapp.com/developer-api-templates.html). The previously present email functionality has also been moved into a sub-resource for improved organization. Error handling has also been made a bit more generic to facilitate it's use across resources.

I've also added some information to the README file.
